### PR TITLE
minimum at 1.8

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -26,8 +26,8 @@
   <target name="compile-boot">
     <mkdir dir="classes"/>
     <!-- Our boot loader, including our "sneaky" class loader -->
-    <javac source="1.7"
-           target="1.7"
+    <javac source="1.8"
+           target="1.8"
            srcdir="srcboot"
            destdir="classes"
            debug="on"
@@ -42,8 +42,8 @@
   <!-- directory, where only our SneakyClassLoader knows to look. -->
   <target name="compile-main">
     <mkdir dir="classes/foo"/>
-    <javac source="1.7"
-           target="1.7"
+    <javac source="1.8"
+           target="1.8"
            classpath="${rhino}"
            srcdir="src"
            destdir="classes/foo"
@@ -110,7 +110,7 @@
   <target name="javadoc">
     <javadoc sourcepath="src:srcboot"
              packagenames="jdbcnav.*,jdbcnavboot.*"
-             source="1.7"
+             source="1.8"
              destdir="javadoc"
              windowtitle="JDBC Navigator">
       <link href="file:///opt/java/jdk1.5.0_10/docs/api"/>


### PR DESCRIPTION
I can't (easily) get a JDK on Mac that lets me target 1.7 and some IDE's wont let you target 1.7 anymore - would be great if moving to 1.8 as then one don't have to do this edit everytime.